### PR TITLE
Convert UTF-16 files to UTF-8 for diffs

### DIFF
--- a/EvergreenAdmx.ps1
+++ b/EvergreenAdmx.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -RunAsAdministrator
+#Requires -RunAsAdministrator
 
 #region init
 <#PSScriptInfo
@@ -2941,6 +2941,19 @@ function Get-MakeMeAdminAdmx {
     }
 }
 
+function ConvertTo-UTF8 {
+    param (
+        [string]$Directory
+    )
+
+    $files = Get-ChildItem -Path $Directory -Recurse -Include *.admx, *.adml
+
+    foreach ($file in $files) {
+        $content = Get-Content -Path $file.FullName
+        $content | Set-Content -Path $file.FullName -Encoding utf8
+    }
+}
+
 #endregion
 
 #region execution
@@ -3178,4 +3191,7 @@ else {
 
 Write-Verbose "`nSaving Admx versions to '$($WorkingDirectory)\admxversions.json'"
 $admxversions | ConvertTo-Json | Set-Content -Path "$($WorkingDirectory)\admxversions.json" -Force
+
+# Convert .admx and .adml files to UTF-8
+ConvertTo-UTF8 -Directory "$($WorkingDirectory)\admx"
 #endregion


### PR DESCRIPTION
Fixes #1

Add function to convert UTF-16 files to UTF-8 for diffs.

* Add `ConvertTo-UTF8` function to `EvergreenAdmx.ps1` to convert `.admx` and `.adml` files to UTF-8
* Call `ConvertTo-UTF8` function at the end of the script to process all `.admx` and `.adml` files in the target directories

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pl4nty/EvergreenAdmx/pull/2?shareId=219acd70-b2d4-494c-bcb2-89f5eedd6116).